### PR TITLE
Fix typo in Exception code

### DIFF
--- a/tf_keras_vis/__init__.py
+++ b/tf_keras_vis/__init__.py
@@ -54,7 +54,7 @@ class ModelVisualization(ABC):
         if len(seed_inputs) != len(self.model.inputs):
             raise ValueError(('The model has {} inputs, '
                               'but the number of seed-inputs tensors you passed is {}.').format(
-                                  len(self.model.outputs), len(seed_inputs)))
+                                  len(self.model.inputs), len(seed_inputs)))
         seed_inputs = (x if tf.is_tensor(x) else tf.constant(x) for x in seed_inputs)
         seed_inputs = (tf.expand_dims(x, axis=0) if len(x.shape) == len(tensor.shape[1:]) else x
                        for x, tensor in zip(seed_inputs, self.model.inputs))


### PR DESCRIPTION
Typo in exception code, which may lead to confusing error messages e.g. if the model has more than one input:

`The model has 1 inputs, but the number of seed-inputs tensors you passed is 1.`

The exception code seems to be copied from method `_get_losses_for_multiple_outputs`, with `len(self.model.outputs)` part left unchanged.