### PR TITLE
fix mis-spelling. matplotllib -> matplotlib

### DIFF
--- a/examples/attentions.ipynb
+++ b/examples/attentions.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade tf-keras-vis tensorflow matplotllib"
+    "!pip install --upgrade tf-keras-vis tensorflow matplotlib"
    ]
   },
   {


### PR DESCRIPTION
fix mis-spelling  in exaples/attention.ipynb

matplotllib -> matplotllib