### PR TITLE
Fix penultimate layer search condition

### DIFF
--- a/tests/tf_keras_vis/utils/model_modifiers_test.py
+++ b/tests/tf_keras_vis/utils/model_modifiers_test.py
@@ -3,7 +3,9 @@ import tensorflow as tf
 
 from tf_keras_vis.activation_maximization import ActivationMaximization
 from tf_keras_vis.saliency import Saliency
-from tf_keras_vis.utils.model_modifiers import (ExtractIntermediateLayer, GuidedBackpropagation,
+from tf_keras_vis.utils.model_modifiers import (ExtractIntermediateLayer,
+                                                ExtractIntermediateLayerForGradcam,
+                                                GuidedBackpropagation,
                                                 ReplaceToLinear)
 from tf_keras_vis.utils.scores import CategoricalScore
 from tf_keras_vis.utils.test import (NO_ERROR, assert_raises, dummy_sample, mock_conv_model,
@@ -47,7 +49,13 @@ class TestExtractIntermediateLayer():
 
 
 class TestExtractIntermediateLayerForGradcam():
-    pass
+    @pytest.mark.parametrize("model", [mock_conv_model(), mock_multiple_outputs_model()])
+    @pytest.mark.parametrize("layer", [None, -1, "conv_1"])
+    @pytest.mark.usefixtures("mixed_precision")
+    def test__call__(self, model, layer):
+        modified_model = ExtractIntermediateLayerForGradcam(layer)(model)
+        assert modified_model != model
+        assert modified_model.outputs[-1].shape.as_list() == [None, 6, 6, 6]
 
 
 class TestExtractGuidedBackpropagation():

--- a/tf_keras_vis/utils/model_modifiers.py
+++ b/tf_keras_vis/utils/model_modifiers.py
@@ -101,14 +101,19 @@ class GuidedBackpropagation(ModelModifier):
 
 
 class ExtractIntermediateLayerForGradcam(ModelModifier):
-    def __init__(self, penultimate_layer=None, seek_penultimate_layer=True, include_model_outputs=True):
+    def __init__(self,
+                 penultimate_layer=None,
+                 seek_penultimate_layer=True,
+                 include_model_outputs=True):
         self.penultimate_layer = penultimate_layer
         self.seek_penultimate_layer = seek_penultimate_layer
         self.include_model_outputs = include_model_outputs
 
     @staticmethod
     def _penultimate_layer_condition(layer):
-        return len(layer.output_shape) == 4 and layer.output_shape[1] > 1 and layer.output_shape[2] > 1
+        return len(layer.output_shape) == 4 and \
+               layer.output_shape[1] > 1 and \
+               layer.output_shape[2] > 1
 
     def __call__(self, model):
         _layer = self.penultimate_layer


### PR DESCRIPTION
Hi there!

Currently the last `Conv` layer is being automatically used for GradCAM if not specified differently. We noticed that for some models like MobileNetV3 this results in the wrong layer being used (as already mentioned in #61).

Specifically to MobileNetV3 this has some problems:
1. The logits layer is implemented using a `Conv2D` layer causing this layer with shape `(None, 1, 1, 1024)` to be selected as the penultimate layer. Obviously this will result in incorrect/useless GradCAM images.
2. Selecting the previous `Conv` layer manually however does not include some important activations which occasionally causes inverted GradCAM images (see #61).

We propose to use a different search condition which searches for the last layer with four dimensions and a width and height of more than 1. This will help both problems mentioned above:
1. The selected layer will have dimensions greater than 1 by 1
2. Important activations will still be included since the penultimate layer doesn't necessarily have to be a `Conv` layer anymore resulting in non-inverted GradCAM images.

A [similar implementation](https://github.com/sicara/tf-explain/blob/3d37ece2445570b2468d51b5ab4cfaf614b21f82/tf_explain/core/grad_cam.py#L86) is being used in [sicara/tf-explain](https://github.com/sicara/tf-explain). Their implementation would however still be affected by the first problem.

I added some quick tests which could be extended in the future.

Let me know what you think!